### PR TITLE
Fix deprecations

### DIFF
--- a/lib/logcraft.rb
+++ b/lib/logcraft.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'logging'
-require 'ostruct'
 
 require 'logcraft/version'
 require 'logcraft/railtie' if defined? Rails
@@ -21,7 +20,7 @@ module Logcraft
   def self.logger(name, level = nil)
     Logging::Logger[name].tap do |logger|
       logger.level = level if level
-      logger.instance_variable_set :@logdev, OpenStruct.new(dev: STDOUT)
+      logger.instance_variable_set :@logdev, Struct.new(:dev).new(STDOUT)
       logger.define_singleton_method :dup do
         super().tap do |logger_copy|
           Logging::Logger.define_log_methods logger_copy

--- a/lib/logcraft/log_layout.rb
+++ b/lib/logcraft/log_layout.rb
@@ -4,7 +4,7 @@ require 'time'
 
 module Logcraft
   class LogLayout < Logging::Layout
-    JSON_FORMATTER = ->(event) { MultiJson.dump(event) + "\n" }.freeze
+    JSON_FORMATTER = ->(event) { MultiJSON.generate(event) + "\n" }.freeze
     LOGGING_LEVEL_FORMATTER = ->(level) { Logging::LNAMES[level] }.freeze
 
     def initialize(global_context = {}, options = {})

--- a/logcraft.gemspec
+++ b/logcraft.gemspec
@@ -30,8 +30,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "logging", "~> 2.0"
   spec.add_dependency "multi_json", "~> 1.14"
+  spec.add_dependency "syslog", "~> 0.3"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", "~> 4.0"
   spec.add_development_dependency "rake", ">= 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/logcraft.gemspec
+++ b/logcraft.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "logging", "~> 2.0"
   spec.add_dependency "multi_json", "~> 1.21"
-  spec.add_dependency "syslog", "~> 0.4"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", ">= 12.0"

--- a/logcraft.gemspec
+++ b/logcraft.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multi_json", "~> 1.21"
   spec.add_dependency "syslog", "~> 0.4"
 
-  spec.add_development_dependency "bundler", "~> 4.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", ">= 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/logcraft.gemspec
+++ b/logcraft.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "logging", "~> 2.0"
-  spec.add_dependency "multi_json", "~> 1.14"
-  spec.add_dependency "syslog", "~> 0.3"
+  spec.add_dependency "multi_json", "~> 1.21"
+  spec.add_dependency "syslog", "~> 0.4"
 
   spec.add_development_dependency "bundler", "~> 4.0"
   spec.add_development_dependency "rake", ">= 12.0"

--- a/spec/logcraft/rails/request_logger_spec.rb
+++ b/spec/logcraft/rails/request_logger_spec.rb
@@ -1,17 +1,9 @@
 # frozen_string_literal: true
 
-require 'ostruct'
-
 RSpec.describe Logcraft::Rails::RequestLogger do
   let(:middleware) { described_class.new app, Logcraft.logger('AccessLog'), config }
-  let(:config) { OpenStruct.new config_options }
-  let(:config_options) do
-    {
-      log_only_whitelisted_params: false,
-      whitelisted_params: [:controller, :action],
-      exclude_paths: []
-    }
-  end
+  let(:config_struct) { Struct.new(:log_only_whitelisted_params, :whitelisted_params, :exclude_paths) }
+  let(:config) { config_struct.new(false, [:controller, :action], []) }
 
   describe '#call' do
     subject(:call) do


### PR DESCRIPTION
Ostruct has been deprecated, replaced with Struct.
MultiJSON has been changed to match JSON methods, so replaced the deprecated method calls.